### PR TITLE
Fix CSS typo

### DIFF
--- a/flipCard/commListCardsFlipStyle.css
+++ b/flipCard/commListCardsFlipStyle.css
@@ -13,7 +13,7 @@
   white-space: normal;
 }
 
-.cTileTextContainter {
+.cTileTextContainer {
   padding: 5px;
   width: 200px;
   height: 200px;


### PR DESCRIPTION
There was a typo in the flip card CSS file that meant some CSS wasn't applied